### PR TITLE
Made the About page responsive for mobile and tab devices

### DIFF
--- a/src/components/CardBlocks.jsx
+++ b/src/components/CardBlocks.jsx
@@ -5,9 +5,9 @@ export default function CardBlocks() {
     "https://cdn.pixabay.com/photo/2016/06/15/16/16/man-1459246_1280.png";
 
   return (
-    <div className="py-[60px]">
-      <div className="max-w-[1000px] mx-auto grid grid-cols-3 gap-[70px]">
-        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300">
+    <div className="py-[60px] flex items-center">
+      <div className="max-w-[1000px] mx-auto flex items-center flex-wrap justify-center">
+        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300 m-[10px]">
           <img
             className="w-28 mx-auto my-[20px] bg-black"
             src={icon1}
@@ -20,7 +20,7 @@ export default function CardBlocks() {
             make a type specimen book. It has survived not
           </p>
         </div>
-        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300">
+        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300 m-[10px]">
           <img
             className="w-28 mx-auto my-[20px] bg-black"
             src={icon1}
@@ -33,7 +33,7 @@ export default function CardBlocks() {
             make a type specimen book. It has survived not
           </p>
         </div>
-        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300">
+        <div className="cards shadow-2xl h-[320px] rounded-xl max-w-[260px] bg-black text-[#ffffff] hover:scale-105 duration-300 m-[10px]">
           <img
             className="w-28 mx-auto my-[20px] bg-black"
             src={icon1}

--- a/src/components/SplitSection.jsx
+++ b/src/components/SplitSection.jsx
@@ -8,12 +8,12 @@ export default function SplitSection() {
     "https://cdn.pixabay.com/photo/2017/01/16/08/27/echo-1983513_1280.png";
 
   return (
-    <div>
-      <div className="cards max-w-[1000px] mx-auto my-[120px] h-[360] grid grid-cols-3 gap-[100px] border">
-        <div className=" h-[360] col-span-1 w-[100%] flex flex-col justify-center">
-          <img src={img1} alt="profile1" class="rounded-[20px] h-[80%]" />
+    <div className="items-center">
+      <div className="cards max-w-[1000px] mx-auto my-[120px] items-center flex flex-col sm:flex-row  sm:space-x-5 border p-[20px] h-fit">
+        <div className="  col-span-1 w-[100%] flex flex-col justify-center items-center sm:items-start">
+          <img src={img1} alt="profile1" class="rounded-[20px] w-[300px] items-center sm:items-start " />
         </div>
-        <div className=" h-[360px] col-span-2 max-w-[645] flex flex-col justify-center">
+        <div className=" h-[360px] col-span-2 max-w-[645] flex flex-col justify-center ">
           <h1 class="cardsText text-black text-[42px] my-2">Who Are We?</h1>
           <h1 class="cardsText text-black text-[30px] my-2">What’s our Story?</h1>
           <p>
@@ -26,7 +26,7 @@ export default function SplitSection() {
           </p>
         </div>
       </div>
-      <div className="cards max-w-[1000px] mx-auto my-[30px] h-[360]   grid grid-cols-3 gap-[100px] border">
+      <div className="cards max-w-[1000px] mx-auto my-[30px] items-center flex flex-col-reverse sm:flex-row  sm:space-x-5 border p-[20px] h-fit">
         <div className="h-[360px] col-span-2 max-w-[645px] flex flex-col justify-center">
           <h1 class="cardsText text-black text-[42px] my-2">We Are Different How?</h1>
           <h1 class="cardsText text-black text-[30px] my-2">What it means?</h1>
@@ -39,7 +39,7 @@ export default function SplitSection() {
             remaining essentially unchanged.
           </p>
         </div>
-        <div className=" h-[360] col-span-1 w-[100%] flex flex-col justify-center">
+        <div className=" h-[360] col-span-1 w-[100%] flex flex-col justify-center items-center sm:items-start">
           <img src={img2} alt="profile2" class="rounded-[20px] w-80" />
         </div>
       </div>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -58,7 +58,8 @@ const TopBar = (props)=>{
       </div>
     </nav>
     <ul
-    className="TopBar bottom-0 bg-[#faddc7] flex flex-row h-[50px] fixed z-10 w-[-webkit-fill-available] space-x-10 justify-center md:hidden"
+    className="TopBar bottom-0 bg-[#faddc7] flex flex-row h-[50px] fixed z-10 w-[-webkit-fill-available] space-x-3
+    sm:space-x-8 md:space-x-12 justify-center md:hidden"
   >
     <li className="flex text-center">
       <Link

--- a/src/index.css
+++ b/src/index.css
@@ -9,9 +9,6 @@
 }
 
 @layer components {
-	.root{
-		width: max-content;
-	}
 	.nav-middle {
 		@apply block py-2 pl-3 pr-4 text-gray-700 rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-blue-700 md:p-0;
 	}
@@ -65,6 +62,10 @@
 	}
 	#dark .cardsText{
 		color: antiquewhite;
+	}
+	#dark .home{
+		width:max-content;
+        background-color: #07062b;
 	}
 }
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,7 +2,7 @@ import { SideBar, BlogCards } from '../components'
 
 const Home = () => {
   return (
-    <div className='flex'>
+    <div className='flex home'>
         <SideBar />
         <BlogCards />
     </div>


### PR DESCRIPTION
Changed SplitSection from grid to flexbox to make it responsive for mobile.

fixes issue #21

![Screenshot (189)](https://user-images.githubusercontent.com/40711348/219851022-63e50654-e52f-4b56-b179-ff2aa2343ca1.png)
![Screenshot (190)](https://user-images.githubusercontent.com/40711348/219851025-bacb5544-7efe-495f-b8d1-b114f710927e.png)
![Screenshot (191)](https://user-images.githubusercontent.com/40711348/219851027-44e87327-4bbe-4a58-b3ce-6d7548511688.png)
![Screenshot (192)](https://user-images.githubusercontent.com/40711348/219851031-76031a8b-955c-4bfe-be6a-ee7d3bc42a88.png)
 